### PR TITLE
Release/1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Rule EC533 google ads consent
+### Changed
+
+### Deleted
+
+## [1.2.0] - 2026-01-04
+
+### Added
+
+- [#102](https://github.com/green-code-initiative/ecoCode-android/pull/102) Add rule EC533 (Google ads consent)
+- [#105](https://github.com/green-code-initiative/ecoCode-android/pull/105) Add rule EC534 (Tracking Id via `TelephonyManager#getDeviceId()`)
+- [#103](https://github.com/green-code-initiative/ecoCode-android/pull/103) Add rule EC549 (Hardware acceleration in Android components, XML)
 
 ### Changed
-- SPRI004: Add rule to avoid use of Tracking Id using TelephonyManager#getDeviceId()
+- [#92](https://github.com/green-code-initiative/ecoCode-android/pull/92) Update EC522 (member select) and related tests
+- Rework BrightnessOverrideRule checks and clean up unused logic
 - The embedded Groovy language analyzer was reconfigured to scan only `.gradle` files since it is the files we are interested in for
   the Android project configuration rules.
   The associated language is named `Groovy (Gradle)` instead of just `Groovy`.
   Since the plugin does not scan `.groovy` files anymore, it can work with a Groovy scanner on the same SonarQube instance.
+- Bump embedded CodeNarc to 2.2.5
+- Remove unused Groovy/CodeNarc extensions and simplify sensors
+- Fix Docker configuration for Apple M1 builds and update the jar path in compose files
+- Update CI workflow and documentation (README/RULES)
 
 ### Deleted
 
@@ -92,7 +107,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First official release of ecocode plugins : android plugin
 
-[unreleased]: https://github.com/green-code-initiative/ecoCode/compare/v1.1.0...HEAD
+[unreleased]: https://github.com/green-code-initiative/ecoCode/compare/v1.2.0...HEAD
+
+[1.2.0]: https://github.com/green-code-initiative/ecoCode/releases/tag/v1.2.0
 
 [1.1.0]: https://github.com/green-code-initiative/ecoCode/releases/tag/v1.1.0
 

--- a/android-plugin/pom.xml
+++ b/android-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
     <groupId>io.ecocode</groupId>
 		<artifactId>ecocode-android-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0</version>
   </parent>
 
 	<artifactId>ecocode-android</artifactId>

--- a/android-plugin/pom.xml
+++ b/android-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
     <groupId>io.ecocode</groupId>
 		<artifactId>ecocode-android-parent</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
 
 	<artifactId>ecocode-android</artifactId>

--- a/codenarc-converter/pom.xml
+++ b/codenarc-converter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.ecocode</groupId>
 	  <artifactId>ecocode-android-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-codenarc-converter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>io.ecocode</groupId>
 	<artifactId>ecocode-android-parent</artifactId>
-	<version>1.1.1-SNAPSHOT</version>
+	<version>1.2.0</version>
 	<packaging>pom</packaging>
 
 	<name>ecoCode Android Sonar Plugins Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>io.ecocode</groupId>
 	<artifactId>ecocode-android-parent</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>ecoCode Android Sonar Plugins Project</name>


### PR DESCRIPTION
## Summary
- Prepare 1.2.0 release (version bump + changelog)
- Tag 1.2.0 (local) and start 1.2.1-SNAPSHOT
- Updates include new rules (EC533/EC534/EC549), Groovy/Gradle analyzer reconfig, CodeNarc 2.2.5, and docs/CI adjustments

## Notes
- main is protected; pushing via release branch
- Tag creation is restricted in repo rules (needs maintainer action)
