### PR TITLE
fix: Use correct path for PGDATA variable in docker-compose & update …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "data:/opt/sonarqube/data"
 
   db:
-    image: postgres:12
+    image: postgres:17
     container_name: postgresql_creedengo-android
     networks:
       - sonarnet
@@ -33,7 +33,7 @@ services:
       POSTGRES_USER: sonar
       POSTGRES_PASSWORD: sonar
       POSTGRES_DB: sonarqube
-      PGDATA: pg_data:/var/lib/postgresql/data/pgdata
+      PGDATA: /var/lib/postgresql/data/pgdata
 
 networks:
   sonarnet:


### PR DESCRIPTION
PGDATA was not correctly set, causing to loose Postgres database when doing docker compose down, because it was not save in volume.

Update postgres to 17 (like creedengo-javascript).